### PR TITLE
Remove PracticeGit

### DIFF
--- a/PracticeGit/brandon.txt
+++ b/PracticeGit/brandon.txt
@@ -1,1 +1,0 @@
-Hello World!

--- a/PracticeGit/matthew.txt
+++ b/PracticeGit/matthew.txt
@@ -1,1 +1,0 @@
-Hello World, from Matthew.

--- a/PracticeGit/test.txt
+++ b/PracticeGit/test.txt
@@ -1,1 +1,0 @@
-Hello World

--- a/PracticeGit/test2
+++ b/PracticeGit/test2
@@ -1,1 +1,0 @@
-hello world, again


### PR DESCRIPTION
To better streamline the cloning process of our project. I think it best to remove PracticeGit folder. It could be confusing since subfolders contain the phase1 and phase2 documentation.